### PR TITLE
Text clarification - compressed public key

### DIFF
--- a/src/www/dev.html
+++ b/src/www/dev.html
@@ -886,7 +886,7 @@
             <fieldset>
               <legend>Result:</legend>
               <label>
-                Public Key (Hex)
+                Compressed Public Key (Hex)
                 <textarea readonly id="singleSigPub" class="textarea-input private-data"></textarea>
               </label>
               <label>


### PR DESCRIPTION
Public key label prepended with the text "compressed" to clarify that prefix 02 or 03 is displayed followed by one 256-bit number and distinguish from uncompressed public key format that is typically presented with the prefix 04 followed by two 256-bit numbers.