### PR TITLE
FIX: Bip47 library link and info on current wallets

### DIFF
--- a/src/www/dev.html
+++ b/src/www/dev.html
@@ -1401,7 +1401,7 @@
               Contributors - MIT</a></li>
           <li><a href="https://github.com/bitcoinjs/bip39" target="_blank" rel="noopener noreferrer">BIP39 by BitcoinJS
               Contributors - MIT</a></li>
-          <li><a href="https://code.samourai.io/dojo/bip47-js" target="_blank" rel="noopener noreferrer">BIP47-js by
+          <li><a href="https://github.com/Dojo-Open-Source-Project/bip47" target="_blank" rel="noopener noreferrer">BIP47-js by
               Samourai - GNU GPL v3</a></li>
           <li><a href="https://github.com/AndreasGassmann/bip85" target="_blank" rel="noopener noreferrer">BIP85 by
               Andreas Gassmann - MIT</a></li>

--- a/src/www/js/info.js
+++ b/src/www/js/info.js
@@ -306,8 +306,7 @@ window.infoHtml = {
         
         
          
-        At the time of writing, the only wallets supporting BIP47 are Samourai and Sparrow. Although here is active development for implementations
-        into BDK and BlueWallet. <br/><br/>
+        At the time of writing, the wallets supporting BIP47 are Ashigaru, BlueWallet, Samourai, Sparrow and Stack Wallet.<br/><br/>
 
         </p>
         <p>


### PR DESCRIPTION
Excuse me for the amount of PRs, but I didn't notice the info on wallets and link to bip47 lib were outdated :-)

I listed the wallets in alphabetical order and avoid repeating "wallet" too much.
Dropped BDK as it [looks totally halted there](https://github.com/bitcoindevkit/bdk/issues/549).