### PR TITLE
FIX: pad raw entropy hex to preserve leading zero bits (#76)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "nodemon ./src/server.js",
     "build": "node ./build.js",
     "git": "npm run build && git pull && git add . && git commit -m \"$MSG\" && git push",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node test/raw-entropy.test.js"
   },
   "author": "SuperPhatArrow",
   "license": "GPLv3",

--- a/src/www/js/dom.js
+++ b/src/www/js/dom.js
@@ -2479,7 +2479,7 @@ const setMnemonicFromEntropy = async () => {
   );
   // check for raw entropy
   if (DOM.entropyMnemonicLengthSelect.value === 'raw') {
-    setMnemonicFromRawEntropy(entropy);
+    await setMnemonicFromRawEntropy(entropy);
     return;
   }
   const mnemonicLength = parseInt(DOM.entropyMnemonicLengthSelect.value);
@@ -2523,17 +2523,41 @@ const setMnemonicFromEntropy = async () => {
   calcBip47();
 };
 
+// Blank every field derived from a previous entropy value, so that an early
+// return or a conversion error can never leave stale seed material on screen.
+const clearDerivedSeedOutputs = () => {
+  DOM.bip39Phrase.value = '';
+  DOM.entropyBinaryChecksum.innerText = '';
+  DOM.entropyWordIndexes.innerText = '';
+  clearCompactSeedQR();
+  clearAddresses();
+};
+
 const setMnemonicFromRawEntropy = async (entropy) => {
   DOM.entropyWeakEntropyOverrideWarning.classList.add('hidden');
   DOM.entropyWeakEntropyWarning.classList.add('hidden');
   let bits = entropy.binaryStr.slice(0, 256);
-  if (bits.length < 128) return; // min bits
-  // user may still be typing
-  if (bits.length % 32 !== 0) return;
-  // convert from bin to hex
-  const phrase = window.bip39.entropyToMnemonic(
-    BigInt('0b' + bits).toString(16)
-  );
+  // Not enough bits yet, or the user may still be typing. Anything already on
+  // screen came from a different entropy value, so clear it.
+  if (bits.length < 128 || bits.length % 32 !== 0) {
+    clearDerivedSeedOutputs();
+    return;
+  }
+  // Convert from bin to hex. BigInt.toString(16) emits the minimal
+  // representation, so pad back to full width, otherwise leading zero bits are
+  // dropped and the mnemonic is short or fails to build entirely.
+  let phrase;
+  try {
+    phrase = window.bip39.entropyToMnemonic(
+      BigInt('0b' + bits)
+        .toString(16)
+        .padStart(bits.length / 4, '0')
+    );
+  } catch (err) {
+    clearDerivedSeedOutputs();
+    console.error('Could not derive a mnemonic from the raw entropy:', err);
+    return;
+  }
   // Set the mnemonic in the UI
   DOM.bip39Phrase.value = phrase;
   makeCompactSeedQR();

--- a/test/raw-entropy.test.js
+++ b/test/raw-entropy.test.js
@@ -1,0 +1,133 @@
+/*
+ * Regression tests for raw entropy mode.
+ *
+ * Guards against the leading zero bug reported in issue #76:
+ * BigInt.prototype.toString(16) emits the minimal hex representation, so a bit
+ * string beginning with one or more zero nibbles produced short hex. That hex
+ * was then either rejected by entropyToMnemonic ("Invalid entropy") or, where
+ * the surviving length happened to still be valid, silently converted into a
+ * mnemonic shorter than the entropy supplied.
+ *
+ * The conversion below mirrors setMnemonicFromRawEntropy in
+ * src/www/js/dom.js. dom.js is browser code and cannot be required directly,
+ * so the expression is duplicated here. Keep the two in sync.
+ */
+
+const assert = require('assert');
+const bip39 = require('../src/www/js/lib/bip39.js');
+
+// Conversion used by setMnemonicFromRawEntropy (src/www/js/dom.js).
+const bitsToMnemonic = (bits) =>
+  bip39.entropyToMnemonic(
+    BigInt('0b' + bits)
+      .toString(16)
+      .padStart(bits.length / 4, '0')
+  );
+
+// The pre-fix conversion, kept only to prove these tests would catch a
+// regression if the padding were ever removed again.
+const bitsToMnemonicUnpadded = (bits) =>
+  bip39.entropyToMnemonic(BigInt('0b' + bits).toString(16));
+
+const ENTROPY_LENGTHS = [128, 160, 192, 224, 256];
+const WORDS_FOR_BITS = { 128: 12, 160: 15, 192: 18, 224: 21, 256: 24 };
+
+let failures = 0;
+const test = (name, fn) => {
+  try {
+    fn();
+    console.log(`  ok  ${name}`);
+  } catch (err) {
+    failures += 1;
+    console.error(`  FAIL ${name}`);
+    console.error(`       ${err.message}`);
+  }
+};
+
+console.log('raw entropy conversion');
+
+// Every supported length, with every leading zero nibble count from 0 to 8,
+// must round trip back to exactly the bits supplied.
+for (const bitLength of ENTROPY_LENGTHS) {
+  for (let zeroNibbles = 0; zeroNibbles <= 8; zeroNibbles += 1) {
+    const leadingZeros = zeroNibbles * 4;
+    const bits =
+      '0'.repeat(leadingZeros) +
+      '1' +
+      '0'.repeat(bitLength - leadingZeros - 1);
+
+    test(`${bitLength} bits, ${zeroNibbles} leading zero nibble(s)`, () => {
+      const phrase = bitsToMnemonic(bits);
+
+      assert.strictEqual(
+        phrase.split(' ').length,
+        WORDS_FOR_BITS[bitLength],
+        `expected ${WORDS_FOR_BITS[bitLength]} words, got ${
+          phrase.split(' ').length
+        }`
+      );
+
+      // No entropy may be lost: converting back must reproduce the input.
+      const roundTrip = BigInt('0x' + bip39.mnemonicToEntropy(phrase))
+        .toString(2)
+        .padStart(bitLength, '0');
+
+      assert.strictEqual(roundTrip, bits, 'round trip lost entropy');
+    });
+  }
+}
+
+// The two vectors from issue #76, asserted against their published values.
+test('issue #76 case 1: 128 bits with four leading zeros', () => {
+  const bits =
+    '00001101100111010010111010001101001011100101110100011010010111001011' +
+    '110110011101001011101000110100101110010111010001101001011100';
+  assert.strictEqual(
+    bitsToMnemonic(bits),
+    'assault truly person frequent spider comic wait place minor indicate ' +
+      'educate ribbon'
+  );
+  // Previously threw "Invalid entropy" and left the old phrase on screen.
+  assert.throws(() => bitsToMnemonicUnpadded(bits), /Invalid entropy/);
+});
+
+test('issue #76 case 2: 256 bits with thirty-two leading zeros', () => {
+  const bits =
+    '00000000000000000000000000000000110110011101001011101000110100101110' +
+    '01011101000110100101110010111101100111010010111010001101001011100101' +
+    '11010001101001011100101111011001110100101110100011010010111001011101' +
+    '0001101001011100101111011001110100101110100011010010';
+  assert.strictEqual(
+    bitsToMnemonic(bits),
+    'abandon abandon ability recipe company harvest nuclear cruise slim ' +
+      'soldier riot place fringe spray control demise trip now inner entire ' +
+      'rural truly person favorite'
+  );
+  // Previously produced a silent 21 word phrase built from bits 33 to 256.
+  assert.strictEqual(bitsToMnemonicUnpadded(bits).split(' ').length, 21);
+});
+
+// The conversion above is a copy, so guard the production source directly:
+// if the padding is removed from dom.js these tests must fail.
+test('src/www/js/dom.js still pads the hex to full width', () => {
+  const fs = require('fs');
+  const path = require('path');
+  const source = fs.readFileSync(
+    path.join(__dirname, '../src/www/js/dom.js'),
+    'utf8'
+  );
+  const conversion = source
+    .slice(source.indexOf('const setMnemonicFromRawEntropy'))
+    .slice(0, 1200);
+
+  assert.ok(
+    /\.padStart\(\s*bits\.length \/ 4,\s*'0'\s*\)/.test(conversion),
+    'setMnemonicFromRawEntropy no longer pads the hex, see issue #76'
+  );
+});
+
+if (failures > 0) {
+  console.error(`\n${failures} test(s) failed`);
+  process.exit(1);
+}
+console.log('\nall tests passed');


### PR DESCRIPTION
Fixes #76.

## Problem

In raw entropy mode, `BigInt.prototype.toString(16)` emits the minimal hex representation, so entropy beginning with one or more zero nibbles lost them before the mnemonic was built. `entropyToMnemonic` then either threw `Invalid entropy` or, where the surviving length was still valid, silently produced a phrase shorter than the entropy supplied.

Because the call was not awaited, the throw became an unhandled rejection and the phrase field was never updated, so the previous run's phrase, QR, checksum and addresses stayed on screen as though they matched the new input.

Reproduced against `bip39@3.1.0` and the vendored `src/www/js/lib/bip39.js`:

| Entropy | Before | After |
| --- | --- | --- |
| 128 bits, 4 leading zeros | 31 hex chars, 15 bytes, throws `Invalid entropy` | `assault truly person frequent spider comic wait place minor indicate educate ribbon` |
| 256 bits, 32 leading zeros | 56 hex chars, 28 bytes, silent 21 word phrase | correct 24 word phrase |

Behaviour varies by length: at 128 bits every leading zero case throws, while at 160 bits and above some cases silently truncate instead. Both modes are covered below.

## Changes

- Pad the hex back to full width with `padStart(bits.length / 4, "0")`. `bits.length` is already guaranteed to be a multiple of 32 at that point.
- `await setMnemonicFromRawEntropy` so a throw is no longer an unhandled rejection.
- Wrap the conversion in `try`/`catch` and log the failure.
- Add `clearDerivedSeedOutputs()` and call it on every early return and on error, clearing the phrase, checksum, word indexes, seed QR and addresses so stale seed material can never be displayed as current.

## Tests

`npm test` now runs `test/raw-entropy.test.js` (plain Node, no new dependencies, uses the vendored bip39 the app ships). 48 assertions:

- 128/160/192/224/256 bit entropy, each with 0 to 8 leading zero nibbles: correct word count, and every mnemonic round trips back to exactly the input bits.
- Both vectors from the issue, asserted against their published phrases, including assertions that the old unpadded conversion throws and produces 21 words respectively.
- A guard that reads `src/www/js/dom.js` and fails if the padding is ever removed. Verified this guard fails when the padding is reverted.

## Not included

`dist/index.html` still contains the bug. It is a signed release artifact rebuilt at release time, so shipping this to users needs a signed release build.